### PR TITLE
feat: implement Queue Cleaning Protocol (DROP instruction)

### DIFF
--- a/src/models/ConversationMessage.ts
+++ b/src/models/ConversationMessage.ts
@@ -38,7 +38,9 @@ export interface ConversationMessage {
  * Routing information parsed from message content
  *
  * v3 extension: Added parentMessageId and intent for causal tracking
+ * v3.1 extension: Added dropTargets for Queue Cleaning Protocol
  * @see docs/design/route_rule/V3/detail/01-data-model.md
+ * @see docs/design/route_rule/V3/queue-cleaning-protocol-engineering.md
  */
 export interface MessageRouting {
   /** Original [NEXT: ...] markers */
@@ -79,6 +81,20 @@ export interface MessageRouting {
    * - P3_EXTEND: Extension/new topic, lowest priority
    */
   intent?: 'P1_INTERRUPT' | 'P2_REPLY' | 'P3_EXTEND';
+
+  // === v3.1 New Fields (Queue Cleaning Protocol) ===
+
+  /**
+   * DROP targets from [DROP: ...] markers (v3.1)
+   *
+   * @remarks
+   * - 'ALL' means clear entire queue
+   * - Member names for targeted removal
+   * - Empty array or undefined means no DROP instruction
+   *
+   * @see docs/design/route_rule/V3/queue-cleaning-protocol-engineering.md
+   */
+  dropTargets?: string[];
 }
 
 /**
@@ -137,6 +153,7 @@ export interface ParsedAddressee {
  * Return value of MessageRouter.parseMessage()
  *
  * v3 extension: Added parsedAddressees with intent information
+ * v3.1 extension: Added dropTargets for Queue Cleaning Protocol
  */
 export interface ParseResult {
   /** Parsed addressee identifiers (legacy, for backward compatibility) */
@@ -158,6 +175,18 @@ export interface ParseResult {
 
   /** Team task from [TEAM_TASK: xxx] marker */
   teamTask?: string;
+
+  /**
+   * DROP targets parsed from [DROP: ...] markers (v3.1)
+   *
+   * @remarks
+   * - 'ALL' means clear entire queue
+   * - Member names indicate targeted removal (raw, pre-normalization)
+   * - Empty array means no DROP instruction
+   *
+   * @see docs/design/route_rule/V3/queue-cleaning-protocol-engineering.md
+   */
+  dropTargets: string[];
 }
 
 /**


### PR DESCRIPTION
Add [DROP: ALL] and [DROP: name] support for clearing routing queue:

- MessageRouter: Add DROP_PATTERN and parseDropTargets() method
- RoutingQueue: Add removeByTarget() and rebuildDedupeSet() methods
- ConversationCoordinator: Add executeDropTargets() with DROP-before-NEXT order
- MessageRouting: Add dropTargets field for storing parsed DROP targets

Key behaviors:
- DROP: ALL clears entire pending queue
- DROP: name removes specific member's pending tasks
- currentRoutingItem and lastCompletedMessageId preserved
- Intent suffixes (!P1/!P2/!P3) stripped from DROP targets

Tests: 26 new test cases for DROP parsing and queue cleaning

🤖 Generated with [Claude Code](https://claude.com/claude-code)